### PR TITLE
Adjust icons to be 100% size

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -193,6 +193,16 @@ h2 {
 }
 
 
+/* icons */
+
+.sidebar-link-home,
+.sidebar-link-models,
+.sidebar-link-map,
+.sidebar-link-about,
+.sidebar-link-contact {
+  background-size: 100%;
+}
+
 /* home */
 
 .sidebar-link-home {


### PR DESCRIPTION
@fixel99 This PR is just because I noticed that the module car icon was very wide. I realised all the icons were being scaled up to fit the space. 

Adding `background-size: 100%` locks them to their desired size. Up to you whether you like them smaller like this version or not.  :)
