### PR TITLE
Move small screen rules to bottom and extend contact

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -138,43 +138,6 @@ h2 {
 }
 
 
-@media (max-width: 991px) {
-  .sidebar {
-    width: 100vw;
-    height: 50px;
-    font-size: 12px;
-  }
-
-  .sidebar-link {
-    float: left;
-    width: 20vw;
-    height: 50px;
-    border-right: 1px solid #666;
-    background-image: none !important;
-  }
-
-  .sidebar-link span {
-    position: static;
-    display: inline-block;
-    padding: 15px 0 0;
-  }
-
-  .sidebar-link span,
-  .sidebar-link:hover span,
-  .is-inview span {
-    color: #fff;
-  }
-
-  .is-inview:after {
-    position: absolute;
-    top: 31px;
-    right: 45%;
-    border-bottom: 10px solid #fff;
-    border-right: 8px solid transparent;
-    border-left: 8px solid transparent;
-  }
-}
-
 
 /* icons */
 
@@ -382,3 +345,48 @@ iframe, object, embed {
     max-width: 100%;
 
 }
+
+/* small sizes */
+
+@media (max-width: 991px) {
+  .sidebar {
+    width: 100vw;
+    height: 50px;
+    font-size: 12px;
+  }
+
+  .sidebar-link {
+    float: left;
+    width: 20vw;
+    height: 50px;
+    border-right: 1px solid #666;
+    background-image: none !important;
+  }
+
+  .sidebar-link span {
+    position: static;
+    display: inline-block;
+    padding: 15px 0 0;
+  }
+
+  .sidebar-link span,
+  .sidebar-link:hover span,
+  .is-inview span {
+    color: #fff;
+  }
+
+  .is-inview:after {
+    position: absolute;
+    top: 31px;
+    right: 45%;
+    border-bottom: 10px solid #fff;
+    border-right: 8px solid transparent;
+    border-left: 8px solid transparent;
+  }
+
+  .tesla-panel-contact {
+    min-height: 120vh;
+  }
+
+}
+


### PR DESCRIPTION
@fixel99 

This PR is to address issue #17 

The reason the contact nav item was never receiving an arrow was because it was not able to scroll slightly long enough in order for the JS to trigger the change.

I've resolved this by cheating slightly - adding a bit more depth to the last container.

```css
.tesla-panel-contact {
  min-height: 120vh;
}
```

I've also taken all small screen rules and moved to the bottom of the style sheet as this stuff should always either be written first or last. In our case, we want it written last as it is being used to over-write rules for wide screen.

